### PR TITLE
fix(injection): Ensure globals array is passed to content script

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -380,14 +380,8 @@ async function getConfigForRegister() {
 		delete tmp.name;
 	}
 
-	// globals
-	for (const i of dbconf.globals) {
-		if (i.enabled) {
-			config[i.name] = i.pattern;
-		}
-	}
-
 	// Pass these full config objects to the rewriter
+	config.globals = dbconf.globals;
 	config.powerFeatures = dbconf.powerFeatures;
 	config.advancedSinks = dbconf.advancedSinks;
 


### PR DESCRIPTION
This commit fixes a critical bug that caused the content script injection to fail in Firefox.

The `getConfigForRegister` function in `background.js` was incorrectly processing the `globals` configuration array, resulting in it being `undefined` in the configuration object passed to the content script. This caused a `TypeError` in `rewriter.js` when it tried to access `CONFIG.globals`.

The fix involves removing the faulty processing loop and directly assigning the `globals` array from storage to the config object. This ensures the content script receives the configuration in the structure it expects, resolving the injection failure.