### PR TITLE
DEBUG: Add logging for function hooking

### DIFF
--- a/src/js/rewriter.js
+++ b/src/js/rewriter.js
@@ -830,11 +830,13 @@ function getInterest(argObj, intrBundle) {
 			const f = getFunc(ownprop[2]);
 			const orig = Object.getOwnPropertyDescriptor(f.where.prototype, f.leaf)[prop];
 			Object.defineProperty(f.where.prototype, f.leaf, {[prop] : new Proxy(orig, ep)});
+			real.log("[HOOKED] %s", evname);
 		} else if (!/^[a-zA-Z.]+$/.test(evname)) {
 			real.log("[EV] name: %s invalid, not hooking", evname);
 		} else {
 			const f = getFunc(evname);
 			f.where[f.leaf] = new Proxy(f.where[f.leaf], ep);
+			real.log("[HOOKED] %s", evname);
 		}
 	}
 


### PR DESCRIPTION
This commit adds detailed console logging to the `rewriter.js` script. For every function sink that is successfully hooked by `applyEvalVillain`, a `[HOOKED] <function_name>` message will be logged to the page's console.

This is a temporary debugging measure to diagnose an issue where sinks appear to be inactive despite the injection logic seeming correct. The logs will help verify which hooks are being applied.