### PR TITLE
Fix advanced sinks, live updates, and hook logic

### DIFF
--- a/src/js/rewriter.js
+++ b/src/js/rewriter.js
@@ -921,9 +921,9 @@ function getInterest(argObj, intrBundle) {
 		if (!CONFIG.advancedSinks) return;
 
 		if (CONFIG.advancedSinks.find(s => s.name === 'ShadowRoot.innerHTML')?.enabled) hookProp(ShadowRoot, 'innerHTML');
-		if (CONFIG.advancedSinks.find(s => s.name === 'Element.insertAdjacentHTML')?.enabled) hookMethod(Element.prototype, 'insertAdjacentHTML');
-		if (CONFIG.advancedSinks.find(s => s.name === 'Range.createContextualFragment')?.enabled) hookMethod(Range.prototype, 'createContextualFragment');
-		if (CONFIG.advancedSinks.find(s => s.name === 'Document.implementation.createHTMLDocument')?.enabled) hookMethod(Document.implementation, 'createHTMLDocument');
+		if (CONFIG.advancedSinks.find(s => s.name === 'Element.insertAdjacentHTML')?.enabled) hookMethod(Element, 'insertAdjacentHTML');
+		if (CONFIG.advancedSinks.find(s => s.name === 'Range.createContextualFragment')?.enabled) hookMethod(Range, 'createContextualFragment');
+		if (CONFIG.advancedSinks.find(s => s.name === 'Document.implementation.createHTMLDocument')?.enabled) hookMethod(DOMImplementation, 'createHTMLDocument', 'Document.implementation.createHTMLDocument');
 		if (CONFIG.advancedSinks.find(s => s.name === 'HTMLIFrameElement.srcdoc')?.enabled) hookProp(HTMLIFrameElement, 'srcdoc');
 		if (CONFIG.advancedSinks.find(s => s.name === 'Element.outerHTML')?.enabled) hookProp(Element, 'outerHTML');
 		if (CONFIG.advancedSinks.find(s => s.name === 'document.domain')?.enabled) hookProp(Document, 'domain');


### PR DESCRIPTION
This commit resolves several critical bugs in the extension:

1.  **Corrected Hooking Logic:** The `hookMethod` helper in `rewriter.js` was being called with incorrect arguments (e.g., `Element.prototype` instead of the `Element` constructor). This has been fixed for `insertAdjacentHTML`, `createContextualFragment`, and `createHTMLDocument`, ensuring these advanced sink hooks are now correctly installed.

2.  **Fixed Live Config Updates:** The live update mechanism was broken because `switcheroo.js` was fetching a pared-down configuration that was missing the `advancedSinks` array. This is fixed by two changes:
    *   `background.js` now broadcasts the fully processed configuration object during updates.
    *   `switcheroo.js` now correctly uses this full configuration from the message payload, ensuring live updates work as intended.

3.  **Consistent Casing:** All instances of `powerfeatures` and `advancedsinks` have been refactored to `powerFeatures` and `advancedSinks` across all HTML and JS files for project-wide consistency.